### PR TITLE
Set dtype for Series constructors (#369)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,8 @@
 * Refactoring of metrics:
   * Remove `GroupMetricResult` type in favour of a `Bunch`.
   * Add `group_summary` transformers.
+* Fix warning due to changing default `dtype` when creating an empty
+  `pandas.Series`.
 
 ### v0.4.5
 * Changes to `ThresholdOptimizer`:

--- a/fairlearn/_input_validation.py
+++ b/fairlearn/_input_validation.py
@@ -85,7 +85,14 @@ def _validate_and_reformat_input(X, y=None, expect_y=True, enforce_binary_sensit
         if len(np.unique(sensitive_features)) > 2:
             raise ValueError(_SENSITIVE_FEATURES_NON_BINARY_ERROR_MESSAGE)
 
-    return pd.DataFrame(X), pd.Series(y), pd.Series(sensitive_features.squeeze())
+    # If we don't have a y, then need to fiddle with return type to
+    # avoid a warning from pandas
+    if y is not None:
+        result_y = pd.Series(y)
+    else:
+        result_y = pd.Series(dtype="float64")
+
+    return pd.DataFrame(X), result_y, pd.Series(sensitive_features.squeeze())
 
 
 def _compress_multiple_sensitive_features_into_single_column(sensitive_features):

--- a/fairlearn/reductions/_exponentiated_gradient/_lagrangian.py
+++ b/fairlearn/reductions/_exponentiated_gradient/_lagrangian.py
@@ -45,9 +45,9 @@ class _Lagrangian:
         self.eps = eps
         self.B = B
         self.opt_lambda = opt_lambda
-        self.hs = pd.Series()
-        self.classifiers = pd.Series()
-        self.errors = pd.Series()
+        self.hs = pd.Series(dtype="float64")
+        self.classifiers = pd.Series(dtype="float64")
+        self.errors = pd.Series(dtype="float64")
         self.gammas = pd.DataFrame()
         self.lambdas = pd.DataFrame()
         self.n = self.X.shape[0]

--- a/fairlearn/reductions/_exponentiated_gradient/exponentiated_gradient.py
+++ b/fairlearn/reductions/_exponentiated_gradient/exponentiated_gradient.py
@@ -83,7 +83,7 @@ class ExponentiatedGradient(BaseEstimator, MetaEstimatorMixin):
                                  self._eps, B)
 
         theta = pd.Series(0, lagrangian.constraints.index)
-        Qsum = pd.Series()
+        Qsum = pd.Series(dtype="float64")
         gaps_EG = []
         gaps = []
         Qs = []

--- a/fairlearn/reductions/_moments/bounded_group_loss.py
+++ b/fairlearn/reductions/_moments/bounded_group_loss.py
@@ -33,7 +33,7 @@ class ConditionalLossMoment(LossMoment):
         attr_vals = self.tags[_GROUP_ID].unique()
         self.pos_basis = pd.DataFrame()
         self.neg_basis = pd.DataFrame()
-        self.neg_basis_present = pd.Series()
+        self.neg_basis_present = pd.Series(dtype='float64')
         zero_vec = pd.Series(0.0, self.index)
         i = 0
         for attr in attr_vals:

--- a/fairlearn/reductions/_moments/conditional_selection_rate.py
+++ b/fairlearn/reductions/_moments/conditional_selection_rate.py
@@ -57,7 +57,7 @@ class ConditionalSelectionRate(ClassificationMoment):
         # speed up GridSearch.
         self.pos_basis = pd.DataFrame()
         self.neg_basis = pd.DataFrame()
-        self.neg_basis_present = pd.Series()
+        self.neg_basis_present = pd.Series(dtype='float64')
         zero_vec = pd.Series(0.0, self.index)
         i = 0
         for event_val in event_vals:


### PR DESCRIPTION
This fixes a `pandas` warning to the effect that

> The default dtype for empty Series will be 'object' instead of 'float64' in a future version. Specify a dtype explicitly to silence this warning. 

Specify the `dtype` to be `float64` in all cases.

Signed-off-by: Richard Edgar <riedgar@microsoft.com>